### PR TITLE
fix: wrong cveId when no CVE alias present

### DIFF
--- a/src/main/java/com/redhat/ecosystemappeng/onguard/model/osv/OsvVulnerability.java
+++ b/src/main/java/com/redhat/ecosystemappeng/onguard/model/osv/OsvVulnerability.java
@@ -27,20 +27,23 @@ public record OsvVulnerability(String id, String summary, String details, List<S
     Date modified, List<Affected> affected) {
 
   public static final Pattern CVE_PATTERN = Pattern.compile("CVE-\\d{4}-\\d{4,7}", Pattern.CASE_INSENSITIVE);
-  
-  public OsvVulnerability {
-    if (!CVE_PATTERN.matcher(id).matches() && aliases != null && !aliases.isEmpty()) {
-      List<String> newAliases = new ArrayList<>();
-      newAliases.add(id);
-      for (String alias : aliases) {
-        if (CVE_PATTERN.matcher(alias).matches()) {
-          id = alias;
-        } else {
-          newAliases.add(alias);
-        }
-      }
-      aliases = Collections.unmodifiableList(newAliases);
-    }
-  }
 
+  public OsvVulnerability {
+    List<String> newAliases = new ArrayList<>();
+    if (aliases == null || aliases.isEmpty()) {
+      aliases = new ArrayList<>();
+    }
+    if(!CVE_PATTERN.matcher(id).matches()) {
+      aliases.add(id);
+      id = null;
+    }
+    for (String alias : aliases) {
+      if (CVE_PATTERN.matcher(alias).matches()) {
+        id = alias;
+      } else {
+        newAliases.add(alias);
+      }
+    }
+    aliases = Collections.unmodifiableList(newAliases);
+  }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/onguard/rest/PurlEndpoint.java
+++ b/src/main/java/com/redhat/ecosystemappeng/onguard/rest/PurlEndpoint.java
@@ -28,6 +28,7 @@ import com.redhat.ecosystemappeng.onguard.service.VulnerabilityService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
 
 @Path("/purls")
 public class PurlEndpoint {
@@ -36,10 +37,10 @@ public class PurlEndpoint {
     VulnerabilityService svc;
 
     @POST
-    public Map<String, List<Vulnerability>> find(PurlsRequest request) {
+    public Map<String, List<Vulnerability>> find(PurlsRequest request, @QueryParam("reload") boolean reload) {
         if(request == null || request.purls() == null || request.purls().isEmpty()) {
             return Collections.emptyMap();
         }
-        return svc.findByPurls(request.purls());
+        return svc.findByPurls(request.purls(), reload);
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/onguard/service/VulnerabilityService.java
+++ b/src/main/java/com/redhat/ecosystemappeng/onguard/service/VulnerabilityService.java
@@ -28,7 +28,7 @@ public interface VulnerabilityService {
 
     List<Vulnerability> find(List<String> vulnIds, boolean reload);
 
-    Map<String, List<Vulnerability>> findByPurls(List<String> purls);
+    Map<String, List<Vulnerability>> findByPurls(List<String> purls, boolean reload);
 
     void ingestNvdVulnerability(Vulnerability vuln);
 

--- a/src/main/java/com/redhat/ecosystemappeng/onguard/service/VulnerabilityServiceImpl.java
+++ b/src/main/java/com/redhat/ecosystemappeng/onguard/service/VulnerabilityServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -73,11 +74,12 @@ public class VulnerabilityServiceImpl implements VulnerabilityService {
         .stream()
         .parallel()
         .map(vuln -> load(vuln, reload))
+        .filter(Objects::nonNull)
         .toList();
   }
 
   @Override
-  public Map<String, List<Vulnerability>> findByPurls(List<String> purls) {
+  public Map<String, List<Vulnerability>> findByPurls(List<String> purls, boolean reload) {
     List<QueryRequestItem> queries = purls.stream().map(purl -> new QueryRequestItem(new PackageRef(purl))).toList();
     var response = osvApi.queryBatch(new QueryRequest(queries));
     Map<String, List<Vulnerability>> vulnerabilities = new HashMap<>();
@@ -87,7 +89,7 @@ public class VulnerabilityServiceImpl implements VulnerabilityService {
       if (resultItem == null || resultItem.vulns() == null) {
         vulnerabilities.put(purl, Collections.emptyList());
       } else {
-        vulnerabilities.put(purl, find(resultItem.vulns().stream().map(VulnerabilityRef::id).toList(), false));
+        vulnerabilities.put(purl, find(resultItem.vulns().stream().map(VulnerabilityRef::id).toList(), reload));
       }
     }
     return vulnerabilities;
@@ -118,7 +120,7 @@ public class VulnerabilityServiceImpl implements VulnerabilityService {
       return vulnAlias.vulnerability();
     }
     var vuln = getOsvVulnerabilityData(vulnAlias.alias());
-    if(vuln == null) {
+    if(vuln == null || vuln.cveId() == null) {
       return null;
     }
     var metrics = nvdService.getCveMetrics(vuln.cveId());
@@ -127,7 +129,7 @@ public class VulnerabilityServiceImpl implements VulnerabilityService {
       updated.metrics(metrics);
     }
     var existing = repository.get(vuln.cveId());
-    if(existing.hasData()) {
+    if(existing != null && existing.hasData()) {
       updated.created(existing.created()).lastModified(new Date());
     } else {
       updated.created(new Date());

--- a/src/test/java/com/redhat/ecosystemappeng/onguard/service/NvdApiTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/onguard/service/NvdApiTest.java
@@ -20,7 +20,6 @@ package com.redhat.ecosystemappeng.onguard.service;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.redhat.ecosystemappeng.onguard.test.WireMockExtensions.CVE_PARAM;
 import static com.redhat.ecosystemappeng.onguard.test.WireMockExtensions.ERROR_503_CVE;
 import static com.redhat.ecosystemappeng.onguard.test.WireMockExtensions.NOT_FOUND;
@@ -31,60 +30,70 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.redhat.ecosystemappeng.onguard.service.nvd.NvdApi;
+import com.redhat.ecosystemappeng.onguard.test.InjectWireMock;
 import com.redhat.ecosystemappeng.onguard.test.WireMockExtensions;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 
 @QuarkusTest
 @QuarkusTestResource(WireMockExtensions.class)
 class NvdApiTest {
 
-    @RestClient
-    NvdApi nvdApi;
+  @RestClient
+  NvdApi nvdApi;
 
-    @Test
-    void testGetFound() {
-        var response = nvdApi.get(VALID_CVE);
-        assertEquals(1, response.totalResults());
-        verify(1, getRequestedFor(urlPathEqualTo(NVD_API_PATH)).withQueryParam(CVE_PARAM, equalTo(VALID_CVE)));
-    }
+  @InjectWireMock
+  WireMockServer server;
 
-    @Test
-    void testGetNotFound() throws InterruptedException {
-        var response = nvdApi.get(NOT_FOUND);
-        assertEquals(0, response.totalResults());
+  static {
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
 
-        // verify it was not retried
-        Thread.sleep(1500);
-        verify(1, getRequestedFor(urlPathEqualTo(NVD_API_PATH)).withQueryParam(CVE_PARAM, equalTo(NOT_FOUND)));
-    }
+  @Test
+  void testGetFound() {
+    var response = nvdApi.get(VALID_CVE);
+    assertEquals(1, response.totalResults());
+    server.verify(1, getRequestedFor(urlPathEqualTo(NVD_API_PATH)).withQueryParam(CVE_PARAM, equalTo(VALID_CVE)));
+  }
 
-    @Test
-    void testGetServerError() throws InterruptedException {
-        var response = nvdApi.get(ERROR_503_CVE);
-        assertEquals(0, response.totalResults());
+  @Test
+  void testGetNotFound() throws InterruptedException {
+    var response = nvdApi.get(NOT_FOUND);
+    assertEquals(0, response.totalResults());
 
-        //verify retry
-        Thread.sleep(1500);
-        verify(2, getRequestedFor(urlPathEqualTo(NVD_API_PATH)).withQueryParam(CVE_PARAM, equalTo(ERROR_503_CVE)));
-    }
+    // verify it was not retried
+    Thread.sleep(1500);
+    server.verify(1, getRequestedFor(urlPathEqualTo(NVD_API_PATH)).withQueryParam(CVE_PARAM, equalTo(NOT_FOUND)));
+  }
 
-    @Test
-    void testList() {
-        var response = nvdApi.list(0, 200, "start_date", "end_date");
-        assertEquals(1, response.totalResults());
-        verify(1, getRequestedFor(urlPathEqualTo(NVD_API_PATH))
-            .withQueryParam("startIndex", equalTo("0")));
-    }
+  @Test
+  void testGetServerError() throws InterruptedException {
+    var response = nvdApi.get(ERROR_503_CVE);
+    assertEquals(0, response.totalResults());
 
-    @Test
-    void testListWithRetry() {
-        var response = nvdApi.list(10, 200, "start_date", "end_date");
+    // verify retry
+    Thread.sleep(1500);
+    server.verify(2, getRequestedFor(urlPathEqualTo(NVD_API_PATH)).withQueryParam(CVE_PARAM, equalTo(ERROR_503_CVE)));
+  }
 
-        assertEquals(1, response.totalResults());
-        verify(2, getRequestedFor(urlPathEqualTo(NVD_API_PATH))
-            .withQueryParam("startIndex", equalTo("10")));
-    }
+  @Test
+  void testList() {
+    var response = nvdApi.list(0, 200, "start_date", "end_date");
+    assertEquals(1, response.totalResults());
+    server.verify(1, getRequestedFor(urlPathEqualTo(NVD_API_PATH))
+        .withQueryParam("startIndex", equalTo("0")));
+  }
+
+  @Test
+  void testListWithRetry() {
+    var response = nvdApi.list(10, 200, "start_date", "end_date");
+
+    assertEquals(1, response.totalResults());
+    server.verify(2, getRequestedFor(urlPathEqualTo(NVD_API_PATH))
+        .withQueryParam("startIndex", equalTo("10")));
+  }
 }


### PR DESCRIPTION
Fix [TC-1006](https://issues.redhat.com/browse/TC-1006)

* Fix issue when the vulnerability doesn't have an associated CVE
* Run WireMock server on dynamicPort
* Allow reload by purl request