### PR TITLE
chore(deps): use mandrel-for-jdk21-rhel8

### DIFF
--- a/src/main/docker/Dockerfile.multi-stage
+++ b/src/main/docker/Dockerfile.multi-stage
@@ -1,5 +1,5 @@
 ## Stage 1 : build with maven builder image with native capabilities
-FROM registry.redhat.io/quarkus/mandrel-23-rhel8:23.0 AS build
+FROM registry.redhat.io/quarkus/mandrel-for-jdk-21-rhel8:23.1 AS build
 
 COPY --chown=quarkus:quarkus mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn


### PR DESCRIPTION
The `mandrel-23-rhel8` image was deprecated